### PR TITLE
No Top Left Corner Radius for Toggle Group Vertical Orientation

### DIFF
--- a/packages/ui/src/components/toggle-group/ToggleGroupItem.astro
+++ b/packages/ui/src/components/toggle-group/ToggleGroupItem.astro
@@ -58,8 +58,8 @@ const {
     // Connected items styling (rounded-none, first/last get border-radius)
     "rounded-none shadow-none first:rounded-l-lg last:rounded-r-lg",
     // Vertical orientation border-radius
-    "group-data-[orientation=vertical]/toggle-group:first:rounded-t-lg group-data-[orientation=vertical]/toggle-group:first:rounded-l-none",
-    "group-data-[orientation=vertical]/toggle-group:last:rounded-b-lg group-data-[orientation=vertical]/toggle-group:last:rounded-r-none",
+    "group-data-[orientation=vertical]/toggle-group:first:rounded-t-lg group-data-[orientation=vertical]/toggle-group:first:rounded-bl-none",
+    "group-data-[orientation=vertical]/toggle-group:last:rounded-b-lg group-data-[orientation=vertical]/toggle-group:last:rounded-tr-none",
     // Outline variant border handling (horizontal)
     "group-data-[variant=outline]/toggle-group:border-l-0 group-data-[variant=outline]/toggle-group:first:border-l",
     // Outline variant border handling (vertical)


### PR DESCRIPTION
Fix missing top-left corner radius on the first item and bottom-right corner radius on the last item in vertical orientation ToggleGroup. Replaced side-based radius utilities (rounded-l-none, rounded-r-none) with individual corner utilities (rounded-bl-none, rounded-tr-none) to prevent them from overriding adjacent corners.