### PR TITLE
fix(dialog): remove extra cn-dialog-close class from close button

### DIFF
--- a/packages/registry/src/ui/dialog/Dialog.astro
+++ b/packages/registry/src/ui/dialog/Dialog.astro
@@ -41,7 +41,7 @@
  *       <p class="text-sm text-muted-foreground ml-8 mt-1">These cookies help us measure the effectiveness of our marketing campaigns.</p>
  *     </div>
  *     <DialogFooter>
- *       <Button data-slot="dialog-close" class="cn-dialog-close mt-4" variant="outline">Close</Button>
+ *       <Button data-slot="dialog-close" class="mt-4" variant="outline">Close</Button>
  *       <Button data-dialog-close class="mt-4">Save changes</Button>
  *     </DialogFooter>
  *   </DialogContent>
@@ -137,7 +137,7 @@
  *       </DialogDescription>
  *     </DialogHeader>
  *     <DialogFooter>
- *       <Button data-slot="dialog-close" class="cn-dialog-close mt-4" variant="outline">Close</Button>
+ *       <Button data-slot="dialog-close" class="mt-4" variant="outline">Close</Button>
  *       <Dialog>
  *         <Button data-slot="dialog-trigger" class="cn-dialog-trigger mt-4">Open Nested Dialog</Button>
  *         <DialogContent class="sm:max-w-md border-red-800">


### PR DESCRIPTION
## Summary
- Removes the unnecessary `cn-dialog-close` class from the Dialog close button examples in `Dialog.astro`
- The `data-slot="dialog-close"` attribute already handles the close behavior, so the extra class was redundant and caused styling issues

## Test plan
- [ ] Verify the dialog close button renders correctly in the docs
- [ ] Confirm the close button still functions properly

Before 
<img width="1420" height="748" alt="CleanShot 2026-04-15 at 10 03 08@2x" src="https://github.com/user-attachments/assets/187dd3f3-c7e3-4107-a07c-19e4d5ec10e2" />
<img width="1372" height="1352" alt="CleanShot 2026-04-15 at 10 03 03@2x" src="https://github.com/user-attachments/assets/0e303cd7-7fe2-474a-a116-091055a07136" />

After
<img width="1298" height="1378" alt="CleanShot 2026-04-15 at 11 25 57@2x" src="https://github.com/user-attachments/assets/d6e7e3b4-8878-4623-927a-c18f5c7931b9" />
<img width="1420" height="716" alt="CleanShot 2026-04-15 at 11 26 02@2x" src="https://github.com/user-attachments/assets/b3e21ca0-8579-40ee-ac40-c0adf705e659" />
