### PR TITLE
Fix custom theme imports

### DIFF
--- a/apps/web/src/components/ThemeSwitcher.astro
+++ b/apps/web/src/components/ThemeSwitcher.astro
@@ -3,6 +3,8 @@ import { Tabs, TabsList, TabsTrigger } from "@bejamas/registry/ui/tabs";
 
 import { SunIcon, MoonIcon, LaptopIcon } from "@lucide/astro";
 import ThemeEditorGlobal from "./theme-editor/ThemeEditorGlobal.astro";
+
+const mountLegacyThemeEditor = !/^\/create(?:\/|$)/.test(Astro.url.pathname);
 ---
 
 <div class="flex items-center" data-theme-switcher-root>
@@ -73,10 +75,13 @@ import ThemeEditorGlobal from "./theme-editor/ThemeEditorGlobal.astro";
   })();
 </script>
 
-<!-- Legacy theme editor stays mounted but hidden during the /create transition. -->
-<div hidden aria-hidden="true">
-  <ThemeEditorGlobal />
-</div>
+{
+  mountLegacyThemeEditor && (
+    <div hidden aria-hidden="true">
+      <ThemeEditorGlobal />
+    </div>
+  )
+}
 
 <script>
   import {

--- a/apps/web/src/components/create/CreateThemeListPanel.astro
+++ b/apps/web/src/components/create/CreateThemeListPanel.astro
@@ -117,6 +117,6 @@ const themeSeedGroups = getCreateThemeSeedGroups(config.baseColor);
       }
     </div>
 
-    <ImportDialog />
+    <ImportDialog scope="create" />
   </div>
 </section>

--- a/apps/web/src/components/theme-editor/ImportDialog.astro
+++ b/apps/web/src/components/theme-editor/ImportDialog.astro
@@ -9,26 +9,50 @@ import {
   DialogTitle,
 } from "@bejamas/ui/components/dialog";
 import { Textarea } from "@bejamas/ui/components/textarea";
+
+interface Props {
+  scope?: "legacy" | "create";
+}
+
+const { scope = "legacy" } = Astro.props as Props;
+const isCreateScope = scope === "create";
+const dialogId = isCreateScope ? "create-theme-import-dialog" : "import-dialog";
+const triggerId = isCreateScope
+  ? "create-theme-import-dialog-trigger"
+  : "import-dialog-trigger";
+const textareaId = isCreateScope
+  ? "create-theme-import-css-textarea"
+  : "import-css-textarea";
+const confirmButtonId = isCreateScope
+  ? "create-theme-import-confirm-btn"
+  : "import-confirm-btn";
 ---
 
-<Dialog id="import-dialog">
+<Dialog
+  id={dialogId}
+  data-create-theme-import-dialog={isCreateScope ? "" : undefined}
+  data-action={isCreateScope
+    ? "dialog:change->create-sidebar#themeImportDialogChanged"
+    : undefined}
+>
   <button
     type="button"
     data-slot="dialog-trigger"
-    id="import-dialog-trigger"
+    id={triggerId}
+    data-create-theme-import-trigger={isCreateScope ? "" : undefined}
     class="hidden"></button>
   <DialogContent class="sm:max-w-lg z-10001">
     <DialogHeader>
       <DialogTitle>Import Custom CSS</DialogTitle>
       <DialogDescription>
-        Paste your CSS file below to customize the theme colors. You can import
-        themes from tweakcn.com or include variables like --primary,
-        --background, etc.
+        Paste CSS variables below to customize theme colors, radius, fonts, and
+        other supported tokens. You can also import themes from tweakcn.com.
       </DialogDescription>
     </DialogHeader>
     <div class="mt-4">
       <Textarea
-        id="import-css-textarea"
+        id={textareaId}
+        data-create-theme-import-textarea={isCreateScope ? "" : undefined}
         class="min-h-[200px] font-mono text-xs max-h-80"
         placeholder={`:root {\n  --background: oklch(1 0 0);\n  --foreground: oklch(0.2 0.044 250);\n  --primary: oklch(0.6 0.2 280);\n  /* And more */\n}\n\n.dark {\n  --background: oklch(0.2 0.02 250);\n  --foreground: oklch(0.97 0.02 250);\n  /* And more */\n}`}
       />
@@ -37,7 +61,13 @@ import { Textarea } from "@bejamas/ui/components/textarea";
       <Button type="button" variant="outline" data-slot="dialog-close">
         Cancel
       </Button>
-      <Button type="button" id="import-confirm-btn">Import</Button>
+      <Button
+        type="button"
+        id={confirmButtonId}
+        data-create-theme-import-confirm={isCreateScope ? "" : undefined}
+      >
+        Import
+      </Button>
     </DialogFooter>
   </DialogContent>
 </Dialog>

--- a/apps/web/src/components/theme-editor/import-dialog.test.ts
+++ b/apps/web/src/components/theme-editor/import-dialog.test.ts
@@ -9,12 +9,48 @@ const source = readFileSync(
   ),
   "utf8",
 );
+const createThemeListSource = readFileSync(
+  path.resolve(
+    process.cwd(),
+    "apps/web/src/components/create/CreateThemeListPanel.astro",
+  ),
+  "utf8",
+);
+const createSidebarControllerSource = readFileSync(
+  path.resolve(
+    process.cwd(),
+    "apps/web/src/stimulus/controllers/create_sidebar_controller.ts",
+  ),
+  "utf8",
+);
 
 describe("ImportDialog", () => {
   test("renders non-submitting action buttons", () => {
     expect(source).toContain(
       '<Button type="button" variant="outline" data-slot="dialog-close">',
     );
-    expect(source).toContain('<Button type="button" id="import-confirm-btn">');
+    expect(source).toContain('type="button"\n        id={confirmButtonId}');
+  });
+
+  test("scopes create controls and binds them outside the sidebar portal", () => {
+    expect(createThemeListSource).toContain('<ImportDialog scope="create" />');
+    expect(source).toContain("data-create-theme-import-dialog=");
+    expect(source).toContain("data-create-theme-import-textarea=");
+    expect(source).toContain("data-create-theme-import-confirm=");
+    expect(source).toContain(
+      "dialog:change->create-sidebar#themeImportDialogChanged",
+    );
+    expect(createSidebarControllerSource).toContain(
+      'document.querySelector<HTMLButtonElement>(\n      "[data-create-theme-import-confirm]"',
+    );
+    expect(createSidebarControllerSource).toContain(
+      'document.querySelector<HTMLTextAreaElement>(\n      "[data-create-theme-import-textarea]"',
+    );
+    expect(createSidebarControllerSource).toContain(
+      'confirmButton.addEventListener("click", this.boundImportConfirm)',
+    );
+    expect(createSidebarControllerSource).toContain(
+      'new CustomEvent("dialog:set"',
+    );
   });
 });

--- a/apps/web/src/components/theme-editor/utils/themeEditorUtils.ts
+++ b/apps/web/src/components/theme-editor/utils/themeEditorUtils.ts
@@ -1,8 +1,12 @@
 import type { ThemeStyles } from "../../../utils/types/theme";
 import { colorFormatter } from "../../../utils/themes/color-converter";
-import { normalizeThemeTokenValue } from "../../../utils/themes/theme-tokens";
+import {
+  COMMON_NON_COLOR_KEYS,
+  normalizeThemeTokenValue,
+  SHADOW_INPUT_KEYS,
+} from "../../../utils/themes/theme-tokens";
 
-const validTokens = new Set([
+const validTokens = new Set<string>([
   "background",
   "foreground",
   "card",
@@ -40,6 +44,15 @@ const validTokens = new Set([
   "footer-primary",
   "footer-primary-foreground",
   "footer-border",
+  ...COMMON_NON_COLOR_KEYS,
+  ...SHADOW_INPUT_KEYS,
+]);
+
+const fontTokens = new Set<string>([
+  "font-sans",
+  "font-heading",
+  "font-serif",
+  "font-mono",
 ]);
 
 export type ThemeStyleValues = {
@@ -128,6 +141,10 @@ export const extractVariables = (
     let value = match[2].trim();
 
     if (!validTokens.has(name)) continue;
+
+    if (fontTokens.has(name)) {
+      value = value.replace(/[“”]/g, '"').replace(/[‘’]/g, "'");
+    }
 
     const hslSpacePattern =
       /^(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)%\s+(\d+(?:\.\d+)?)%$/;

--- a/apps/web/src/components/theme-switcher.test.ts
+++ b/apps/web/src/components/theme-switcher.test.ts
@@ -28,6 +28,10 @@ describe("theme switcher", () => {
     expect(source).toContain('tabsRoot.dataset.themeChoiceIndex = themeChoiceIndex;');
     expect(source).toContain("syncThemeChoiceControls(");
     expect(source).toContain("setThemeChoice(nextTheme);");
+    expect(source).toContain(
+      "const mountLegacyThemeEditor = !/^\\/create(?:\\/|$)/.test(Astro.url.pathname);",
+    );
+    expect(source).toContain("mountLegacyThemeEditor && (");
     expect(preloadIndex).toBeGreaterThan(-1);
     expect(hiddenThemeEditorIndex).toBeGreaterThan(-1);
     expect(preloadIndex).toBeLessThan(hiddenThemeEditorIndex);

--- a/apps/web/src/stimulus/controllers/create_editor_controller.ts
+++ b/apps/web/src/stimulus/controllers/create_editor_controller.ts
@@ -477,6 +477,13 @@ export default class extends Controller<HTMLElement> {
     }
 
     const parsed = parseCssVariables(css);
+    const importedTokenCount =
+      Object.keys(parsed.light).length + Object.keys(parsed.dark).length;
+    if (importedTokenCount === 0) {
+      this.setThemeStatus("No supported CSS variables found.");
+      return;
+    }
+
     const baseline = this.getBaselineThemeStyles(config);
     const overrides = normalizeThemeOverrides(this.themeOverrides);
 

--- a/apps/web/src/stimulus/controllers/create_sidebar_controller.ts
+++ b/apps/web/src/stimulus/controllers/create_sidebar_controller.ts
@@ -92,11 +92,12 @@ export default class extends Controller<HTMLElement> {
   private activePanel: CreateSidebarPanel = "main";
   private transitionToken = 0;
   private lastRenderState: CreateSidebarRenderState | null = null;
+  private boundImportConfirmButton: HTMLButtonElement | null = null;
   private readonly boundImportConfirm = (event: Event) =>
     this.confirmThemeImport(event);
 
   connect() {
-    this.importConfirmButton?.addEventListener("click", this.boundImportConfirm);
+    this.bindThemeImportControls();
     this.activePanel = this.panelValue || "main";
     this.isReady = true;
     this.applyPanelStateImmediately(this.currentPanel);
@@ -104,10 +105,7 @@ export default class extends Controller<HTMLElement> {
   }
 
   disconnect() {
-    this.importConfirmButton?.removeEventListener(
-      "click",
-      this.boundImportConfirm,
-    );
+    this.unbindThemeImportControls();
   }
 
   colorInputTargetConnected(target: ColorInputElement) {
@@ -293,7 +291,19 @@ export default class extends Controller<HTMLElement> {
   }
 
   openThemeImportDialog() {
-    this.importDialogTrigger?.click();
+    this.themeImportDialog?.dispatchEvent(
+      new CustomEvent("dialog:set", {
+        detail: {
+          open: true,
+        },
+      }),
+    );
+  }
+
+  themeImportDialogChanged(event: CustomEvent<{ open: boolean }>) {
+    if (event.detail.open) {
+      this.bindThemeImportControls();
+    }
   }
 
   confirmThemeImport(event?: Event) {
@@ -315,26 +325,51 @@ export default class extends Controller<HTMLElement> {
     this.panelValue = "theme-list";
   }
 
-  private get importDialogTrigger() {
-    return this.element.querySelector<HTMLButtonElement>("#import-dialog-trigger");
+  private bindThemeImportControls() {
+    const confirmButton = this.importConfirmButton;
+    if (!confirmButton || confirmButton === this.boundImportConfirmButton) {
+      return;
+    }
+
+    this.unbindThemeImportControls();
+    confirmButton.addEventListener("click", this.boundImportConfirm);
+    this.boundImportConfirmButton = confirmButton;
+  }
+
+  private unbindThemeImportControls() {
+    this.boundImportConfirmButton?.removeEventListener(
+      "click",
+      this.boundImportConfirm,
+    );
+    this.boundImportConfirmButton = null;
+  }
+
+  private get themeImportDialog() {
+    return this.element.querySelector<HTMLElement>(
+      "[data-create-theme-import-dialog]",
+    );
   }
 
   private get importConfirmButton() {
-    return this.element.querySelector<HTMLButtonElement>("#import-confirm-btn");
+    return document.querySelector<HTMLButtonElement>(
+      "[data-create-theme-import-confirm]",
+    );
   }
 
   private get importTextarea() {
-    return this.element.querySelector<HTMLTextAreaElement>("#import-css-textarea");
-  }
-
-  private get importDialogCloseButton() {
-    return this.element.querySelector<HTMLElement>(
-      "#import-dialog [data-slot='dialog-close']",
+    return document.querySelector<HTMLTextAreaElement>(
+      "[data-create-theme-import-textarea]",
     );
   }
 
   closeThemeImportDialog() {
-    this.importDialogCloseButton?.click();
+    this.themeImportDialog?.dispatchEvent(
+      new CustomEvent("dialog:set", {
+        detail: {
+          open: false,
+        },
+      }),
+    );
   }
 
   private get currentPanel(): CreateSidebarPanel {

--- a/apps/web/src/utils/themes/create-theme.test.ts
+++ b/apps/web/src/utils/themes/create-theme.test.ts
@@ -70,6 +70,54 @@ describe("create theme helpers", () => {
     expect(parsed.dark.primary).toContain("oklch(");
   });
 
+  test("imports radius and font tokens from pasted CSS", () => {
+    const parsed = parseCssVariables(`
+      :root {
+        --background: #FFFFFF;
+        --foreground: #0A0A0A;
+        --card: #FFFFFF;
+        --card-foreground: #0A0A0A;
+        --popover: #FFFFFF;
+        --popover-foreground: #0A0A0A;
+        --primary: #D15B05;
+        --primary-foreground: #FFFFFF;
+        --secondary: #F3F6F8;
+        --secondary-foreground: #0A0A0A;
+        --muted: #F3F6F8;
+        --muted-foreground: #5F6068;
+        --accent: #E8F2F4;
+        --accent-foreground: #036093;
+        --destructive: #C0392B;
+        --destructive-foreground: #FFFFFF;
+        --border: #D5D9DE;
+        --input: #D5D9DE;
+        --ring: #D15B05;
+        --chart-1: #D15B05;
+        --chart-2: #28A9E0;
+        --chart-3: #036093;
+        --chart-4: #135E69;
+        --chart-5: #D83269;
+        --sidebar: #FFFFFF;
+        --sidebar-foreground: #0A0A0A;
+        --sidebar-primary: #D15B05;
+        --sidebar-primary-foreground: #FFFFFF;
+        --sidebar-accent: #F3F6F8;
+        --sidebar-accent-foreground: #0A0A0A;
+        --sidebar-border: #D5D9DE;
+        --sidebar-ring: #D15B05;
+        --radius: 0.5rem;
+        --font-sans: “Helvetica Now Display”, Helvetica, Arial, sans-serif;
+      }
+    `);
+
+    expect(Object.keys(parsed.light)).toHaveLength(34);
+    expect(parsed.light.primary).toContain("oklch(");
+    expect(parsed.light.radius).toBe("0.5rem");
+    expect(parsed.light["font-sans"]).toBe(
+      '"Helvetica Now Display", Helvetica, Arial, sans-serif',
+    );
+  });
+
   test("formats token labels for the theme panel", () => {
     expect(formatThemeTokenLabel("primary-foreground")).toBe(
       "Primary Foreground",


### PR DESCRIPTION
## Summary
- bind the create theme import dialog through portal-safe, instance-scoped hooks
- remove the duplicate legacy theme editor from `/create`
- import radius, font, spacing, and shadow tokens, including smart-quote normalization
- keep the dialog open when pasted CSS has no supported variables
- add regression coverage for the supplied 34-token theme

## Verification
- `bun test apps/web/src/components/theme-editor/import-dialog.test.ts apps/web/src/components/theme-switcher.test.ts apps/web/src/utils/themes/create-theme.test.ts apps/web/src/tests/pages/create.test.ts`
- `bun run --cwd apps/web check-types`
- browser-verified the supplied CSS in `/create`: primary `oklch(0.6111 0.1683 46.6465)`, radius `0.5rem`, and normalized Helvetica font stack applied in the light preview