### PR TITLE
Disable previews in API Reference sections

### DIFF
--- a/.changeset/huge-flowers-worry.md
+++ b/.changeset/huge-flowers-worry.md
@@ -1,0 +1,5 @@
+---
+"bejamas": patch
+---
+
+Disable component previews in generated API Reference sections.

--- a/packages/bejamas/src/docs/generate-mdx/examples.ts
+++ b/packages/bejamas/src/docs/generate-mdx/examples.ts
@@ -67,6 +67,7 @@ export interface FenceInfo {
 
 interface PreviewRenderConfig {
   defaultPreview?: boolean;
+  allowForcedPreview?: boolean;
 }
 
 type MutableSection = {
@@ -486,7 +487,7 @@ export function extractComponentTagsFromPreviewMarkdown(
   config: PreviewRenderConfig = {},
 ): string[] {
   if (!block || !block.length) return [];
-  const { defaultPreview = true } = config;
+  const { defaultPreview = true, allowForcedPreview = true } = config;
   const found = new Set<string>();
   const lines = block.split("\n");
   let inFence = false;
@@ -516,7 +517,8 @@ export function extractComponentTagsFromPreviewMarkdown(
         const hasForcedPreviewFlag =
           currentFenceFlags.has("preview") || currentFenceFlags.has("console");
         const shouldPreview =
-          !prepared.skipPreview && (defaultPreview || hasForcedPreviewFlag);
+          !prepared.skipPreview &&
+          (defaultPreview || (allowForcedPreview && hasForcedPreviewFlag));
         if (shouldPreview) {
           for (const tag of extractTags(prepared.snippet)) found.add(tag);
         }

--- a/packages/bejamas/src/docs/generate-mdx/index.ts
+++ b/packages/bejamas/src/docs/generate-mdx/index.ts
@@ -306,9 +306,10 @@ async function main() {
     const usedInPrimary = extractComponentTagsFromMDX(primaryExampleMDX).filter(
       (n) => n !== pascal,
     );
-    const usedInApi = extractComponentTagsFromPreviewMarkdown(apiMDX).filter(
-      (n) => n !== pascal,
-    );
+    const usedInApi = extractComponentTagsFromPreviewMarkdown(apiMDX, {
+      defaultPreview: false,
+      allowForcedPreview: false,
+    }).filter((n) => n !== pascal);
     const autoSet = new Set<string>([
       ...usedInUsage,
       ...usedInDescription,

--- a/packages/bejamas/src/docs/generate-mdx/mdx-builder.ts
+++ b/packages/bejamas/src/docs/generate-mdx/mdx-builder.ts
@@ -377,6 +377,7 @@ export function buildMdx(params: {
 
   type MarkdownPreviewConfig = {
     defaultPreview?: boolean;
+    allowForcedPreview?: boolean;
   };
 
   const extractInlineScripts = (snippet: string): {
@@ -619,7 +620,7 @@ ${preparedPreview.markup}
     config: MarkdownPreviewConfig = {},
   ): string => {
     if (!block || !block.length) return block;
-    const { defaultPreview = true } = config;
+    const { defaultPreview = true, allowForcedPreview = true } = config;
 
     const lines = block.split("\n");
     const out: string[] = [];
@@ -689,7 +690,8 @@ ${preparedPreview.markup}
           const hasForcedPreviewFlag =
             currentFenceFlags.has("preview") || currentFenceFlags.has("console");
           const shouldPreview =
-            !prepared.skipPreview && (defaultPreview || hasForcedPreviewFlag);
+            !prepared.skipPreview &&
+            (defaultPreview || (allowForcedPreview && hasForcedPreviewFlag));
           if (
             prepared.snippet &&
             prepared.snippet.length &&
@@ -808,7 +810,10 @@ ${preparedPreview.markup}
   const renderedUsageMDX = renderAstroPreviewsInMarkdown(usageMDX || "", {
     defaultPreview: false,
   });
-  const renderedApiMDX = renderAstroPreviewsInMarkdown(apiMDX || "");
+  const renderedApiMDX = renderAstroPreviewsInMarkdown(apiMDX || "", {
+    defaultPreview: false,
+    allowForcedPreview: false,
+  });
 
   const primaryExampleSection =
     primaryExampleMDX && primaryExampleMDX.length

--- a/packages/bejamas/test/examples-parser.test.ts
+++ b/packages/bejamas/test/examples-parser.test.ts
@@ -226,6 +226,18 @@ import { SearchIcon } from '@lucide/astro';
     expect(tags).not.toContain("InputGroup");
   });
 
+  test("skips forced preview tags when previews are disabled for a section", () => {
+    const markdown = `\`\`\`astro preview
+<Button />
+\`\`\``;
+    const tags = extractComponentTagsFromPreviewMarkdown(markdown, {
+      defaultPreview: false,
+      allowForcedPreview: false,
+    });
+
+    expect(tags).toEqual([]);
+  });
+
   test("ignores nopreview astro fences when extracting preview component tags", () => {
     const markdown = `\`\`\`astro nopreview
 <Field>
@@ -686,7 +698,7 @@ const { class: className = "", ...props } = Astro.props;
     expect(mdx).not.toContain("data-slot=\"event-log\"");
   });
 
-  test("strips script tags from injected previews but keeps source fence unchanged", () => {
+  test("does not render previews for astro fences in API Reference", () => {
     const mdx = buildMdx({
       importName: "Popover",
       importPath: "@bejamas/ui/components/popover",
@@ -709,7 +721,7 @@ const { class: className = "", ...props } = Astro.props;
       commandName: "popover",
       componentsAlias: "@bejamas/ui/components",
       namedExports: ["PopoverContent", "PopoverTrigger"],
-      apiMDX: `\`\`\`astro
+      apiMDX: `\`\`\`astro preview
 <Popover id="my-popover">
   <PopoverTrigger variant="outline">Open</PopoverTrigger>
   <PopoverContent>
@@ -725,14 +737,13 @@ const { class: className = "", ...props } = Astro.props;
 \`\`\``,
     });
 
-    expect(mdx).toContain("sl-bejamas-component-preview");
+    expect(mdx).toContain("## API Reference");
+    expect(mdx).not.toContain("sl-bejamas-component-preview");
     expect(mdx).toContain("<Popover id=\"my-popover\">");
-    expect(mdx).not.toContain(
-      "<script> const popover = document.getElementById('my-popover');",
-    );
 
-    const sourceMatch = mdx.match(/```astro\n([\s\S]*?)\n```/);
+    const sourceMatch = mdx.match(/```astro preview\n([\s\S]*?)\n```/);
     expect(sourceMatch).toBeTruthy();
+    expect(sourceMatch![1]).toContain("<script>");
     expect(sourceMatch![1]).toContain("popover.addEventListener");
     expect(sourceMatch![1]).toContain("console.log('Is open:', e.detail.open);");
   });


### PR DESCRIPTION
## Summary

- disable generated component previews in API Reference sections
- keep Astro source fences while avoiding preview-only auto imports
- prevent `preview` and `console` fence flags from forcing previews in API Reference

## Testing

- `bun test packages/bejamas/test/examples-parser.test.ts`
- `bun run build --filter=bejamas`
- generated and inspected `field.mdx` to verify API Reference code blocks have no preview wrapper

## Note

The broader package suite was also run. Its only failure is unrelated: `tailwind-css-package.test.ts` expects the absent local fixture `tmp/shadcn-ui/packages/shadcn/src/tailwind.css`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/bejamas/codesmith/ui/pr/134"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790748515&installation_model_id=433409&pr_number=134&repository=bejamas%2Fui&return_to=https%3A%2F%2Fgithub.com%2Fbejamas%2Fui%2Fpull%2F134&signature=0fc63eabd077be126a638302a6ed1a68c8862c0c416ca0d4dae28ddbf113b0bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->